### PR TITLE
:arrow_up: Use python 3.12 in Build Documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.12
     - name: Get Job URL
       uses: Tiryoh/gha-jobid-action@v1
       id: jobs


### PR DESCRIPTION
:arrow_up: Use python 3.12 in Build Documentation